### PR TITLE
Update Android Gradle Plugin to 9.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.0"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "35"


### PR DESCRIPTION
This PR updates the Android Gradle Plugin from version 8.13.2 to 9.0.0.

## Changes
- Updated AGP version from 8.13.2 to 9.0.0 in gradle/libs.versions.toml
- Gradle 9.0.0 is already compatible with AGP 9.0.0

Closes #33

Generated with [Claude Code](https://claude.ai/code)