### PR TITLE
Refactor: Use mapValues extension function for Flow transformations

### DIFF
--- a/database/src/commonMain/kotlin/ru/pavlig43/database/data/product/dao/ProductDeclarationDao.kt
+++ b/database/src/commonMain/kotlin/ru/pavlig43/database/data/product/dao/ProductDeclarationDao.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import ru.pavlig43.core.getCurrentLocalDate
+import ru.pavlig43.core.mapValues
 import ru.pavlig43.database.data.common.NotificationDTO
 import ru.pavlig43.database.data.declaration.Declaration
 import ru.pavlig43.database.data.product.Product
@@ -44,8 +45,7 @@ abstract class ProductDeclarationDao {
     internal abstract fun observeOnProductDeclaration(): Flow<List<InternalProductDeclaration>>
 
     fun observeOnProductDeclarationOut(): Flow<List<ProductDeclarationOut>> {
-        return observeOnProductDeclaration().map{lst->
-            lst.map(InternalProductDeclaration::toProductDeclarationOut)}
+        return observeOnProductDeclaration().mapValues(InternalProductDeclaration::toProductDeclarationOut)
     }
 
 

--- a/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/OneModule.kt
+++ b/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/OneModule.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.koin.dsl.module
 import ru.pavlig43.core.DateThreshold
+import ru.pavlig43.core.mapValues
 import ru.pavlig43.database.NocombroDatabase
 import ru.pavlig43.notification.api.model.NotificationItem
 import ru.pavlig43.notification.api.model.NotificationLevel
@@ -26,13 +27,11 @@ private class DeclarationOneRepository(
     override val notificationLevel: NotificationLevel = NotificationLevel.MEDIUM
     override val notificationItem: NotificationItem = NotificationItem.Declaration
     private val getOnOneMountExpiredDeclaration: Flow<List<NotificationUi>> =
-        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.OneMonth).map { lst ->
-            lst.map { notificationDTO ->
-                NotificationUi(
-                    id = notificationDTO.id,
-                    text = notificationDTO.displayName
-                )
-            }
+        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.OneMonth).mapValues { notificationDTO ->
+            NotificationUi(
+                id = notificationDTO.id,
+                text = notificationDTO.displayName
+            )
         }
 
     override val mergedFromDBNotificationFlow: Flow<List<NotificationUi>> =

--- a/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/TwoModule.kt
+++ b/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/TwoModule.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.koin.dsl.module
 import ru.pavlig43.core.DateThreshold
+import ru.pavlig43.core.mapValues
 import ru.pavlig43.database.NocombroDatabase
 import ru.pavlig43.notification.api.model.NotificationItem
 import ru.pavlig43.notification.api.model.NotificationLevel
@@ -26,13 +27,11 @@ private class DeclarationTwoRepository(
     override val notificationItem: NotificationItem = NotificationItem.Declaration
 
     private val getOnThreeMountExpiredDeclaration =
-        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.ThreeMonth).map { lst ->
-            lst.map { notificationDTO ->
-                NotificationUi(
-                    id = notificationDTO.id,
-                    text = notificationDTO.displayName
-                )
-            }
+        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.ThreeMonth).mapValues { notificationDTO ->
+            NotificationUi(
+                id = notificationDTO.id,
+                text = notificationDTO.displayName
+            )
         }
     override val mergedFromDBNotificationFlow: Flow<List<NotificationUi>> =
         combine(

--- a/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/ZeroModule.kt
+++ b/features/notification/src/commonMain/kotlin/ru/pavlig43/notification/internal/di/ZeroModule.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.koin.dsl.module
 import ru.pavlig43.core.DateThreshold
+import ru.pavlig43.core.mapValues
 import ru.pavlig43.database.NocombroDatabase
 import ru.pavlig43.notification.api.model.NotificationItem
 import ru.pavlig43.notification.api.model.NotificationLevel
@@ -24,13 +25,11 @@ private class DocumentZeroRepository(
     override val notificationLevel: NotificationLevel = NotificationLevel.HIGH
     override val notificationItem: NotificationItem = NotificationItem.Document
     override val mergedFromDBNotificationFlow: Flow<List<NotificationUi>> =
-        db.documentDao.observeOnItemWithoutFiles().map { lst ->
-            lst.map { notificationDTO ->
-                NotificationUi(
-                    id = notificationDTO.id,
-                    text = "В документе ${notificationDTO.displayName} нет файлов"
-                )
-            }
+        db.documentDao.observeOnItemWithoutFiles().mapValues { notificationDTO ->
+            NotificationUi(
+                id = notificationDTO.id,
+                text = "В документе ${notificationDTO.displayName} нет файлов"
+            )
         }
 }
 
@@ -39,22 +38,18 @@ private class DeclarationZeroRepository(
 ) : INotificationRepository {
 
     private val declarationWithoutDocument =
-        db.declarationDao.observeOnItemWithoutFiles().map { lst ->
-            lst.map { notificationDTO ->
-                NotificationUi(
-                    id = notificationDTO.id,
-                    text = "В декларации ${notificationDTO.displayName} нет файлов"
-                )
-            }
+        db.declarationDao.observeOnItemWithoutFiles().mapValues { notificationDTO ->
+            NotificationUi(
+                id = notificationDTO.id,
+                text = "В декларации ${notificationDTO.displayName} нет файлов"
+            )
         }
     private val getOnExpiredDeclaration =
-        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.Now).map { lst ->
-            lst.map { notificationDTO ->
-                NotificationUi(
-                    id = notificationDTO.id,
-                    text = notificationDTO.displayName
-                )
-            }
+        db.declarationDao.observeOnExpiredDeclaration(DateThreshold.Now).mapValues { notificationDTO ->
+            NotificationUi(
+                id = notificationDTO.id,
+                text = notificationDTO.displayName
+            )
         }
 
 
@@ -78,25 +73,19 @@ private class ProductZeroRepository(
     override val notificationItem: NotificationItem = NotificationItem.Product
     private val productDeclaration =
         db.productDeclarationDao.observeOnProductDeclarationNotification { db.productDao.observeOnProducts() }
-            .map { lst ->
-                lst.map { notificationDTO ->
-                    NotificationUi(
-                        id = notificationDTO.id,
-                        text = notificationDTO.displayName
-                    )
-                }
-
+            .mapValues { notificationDTO ->
+                NotificationUi(
+                    id = notificationDTO.id,
+                    text = notificationDTO.displayName
+                )
             }
     private val productComposition =
         db.compositionDao.observeProductWithoutComposition { db.productDao.observeOnProducts() }
-            .map { lst ->
-                lst.map { notificationDTO ->
-                    NotificationUi(
-                        id = notificationDTO.id,
-                        text = notificationDTO.displayName
-                    )
-                }
-
+            .mapValues { notificationDTO ->
+                NotificationUi(
+                    id = notificationDTO.id,
+                    text = notificationDTO.displayName
+                )
             }
 
     override val mergedFromDBNotificationFlow: Flow<List<NotificationUi>> =


### PR DESCRIPTION
## Описание
Заменил вложенный паттерн `.map { lst -> lst.map {...} }` на функцию-расширение `mapValues`.

## Изменения
- **ProductDeclarationDao.kt**: `observeOnProductDeclarationOut()`
- **ZeroModule.kt**: DocumentZeroRepository, DeclarationZeroRepository (2 места), ProductZeroRepository (2 места)
- **OneModule.kt**: DeclarationOneRepository
- **TwoModule.kt**: DeclarationTwoRepository

## Результат
- **-13 строк кода**
- Улучшена читаемость
- Использована специализированная функция для трансформации Flow коллекций

## Пример
**Было:**
```kotlin
flow.map { lst ->
    lst.map { transform(it) }
}
```

**Стало:**
```kotlin
flow.mapValues { transform(it) }
```