### PR TITLE
feat: add autoWidth and horizontal padding to all table columns

### DIFF
--- a/features/table/flowImmutable/src/commonMain/kotlin/ru/pavlig43/flowImmutable/api/component/column/SelectedCheckBox.kt
+++ b/features/table/flowImmutable/src/commonMain/kotlin/ru/pavlig43/flowImmutable/api/component/column/SelectedCheckBox.kt
@@ -2,6 +2,7 @@ package ru.pavlig43.flowImmutable.api.component.column
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
@@ -58,7 +59,12 @@ private fun <T : IMultiLineTableUi, C, E : TableData<T>> ReadonlyTableColumnsBui
     column(idKey, valueOf = { it.composeId }) {
         header("Ид")
         align(Alignment.Center)
-        cell { item, _ -> Text(item.composeId.toString()) }
+        cell { item, _ ->
+            Text(
+                text = item.composeId.toString(),
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+        }
         autoWidth(max = 500.dp)
 
     }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DateColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DateColumn.kt
@@ -20,6 +20,7 @@ fun <T : Any, C, E> ReadonlyTableColumnsBuilder<T, C, E>.readDateColumn(
     filterType: TableFilterType.DateTableFilter? = null
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filterType?.let {
@@ -36,7 +37,7 @@ private fun <T : Any, C, E> ReadonlyColumnBuilder<T, C, E>.readDateCell(
     cell { item, _ ->
         Text(
             text = valueOf(item).format(dateFormat),
-            modifier = Modifier.padding(start = 12.dp)
+            modifier = Modifier.padding(horizontal = 12.dp)
         )
     }
 }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DateTimeColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DateTimeColumn.kt
@@ -20,6 +20,7 @@ fun <T : Any, C, E> ReadonlyTableColumnsBuilder<T, C, E>.readDateTimeColumn(
     filterType: TableFilterType.DateTableFilter? = null
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filterType?.let {
@@ -36,7 +37,7 @@ private fun <T : Any, C, E> ReadonlyColumnBuilder<T, C, E>.readDateTimeCell(
     cell { item, _ ->
         Text(
             text = valueOf(item).format(dateTimeFormat),
-            modifier = Modifier.padding(start = 12.dp)
+            modifier = Modifier.padding(horizontal = 12.dp)
         )
     }
 }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DecimalColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/DecimalColumn.kt
@@ -2,6 +2,8 @@ package ru.pavlig43.immutable.internal.column
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import ua.wwind.table.ReadonlyColumnBuilder
 import ua.wwind.table.ReadonlyTableColumnsBuilder
 import kotlin.math.pow
@@ -29,6 +31,7 @@ fun <T : Any, C, E> ReadonlyTableColumnsBuilder<T, C, E>.readDecimalColumn(
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = { valueOf(it) }) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         readDecimalCell(format = decimalFormat, getCount = valueOf)
@@ -41,7 +44,10 @@ private fun <T : Any, C, E> ReadonlyColumnBuilder<T, C, E>.readDecimalCell(
     getCount: (T) -> Int,
 ) {
     cell { item, _ ->
-        Text(text = getCount(item).toStartDoubleFormat(format))
+        Text(
+            text = getCount(item).toStartDoubleFormat(format),
+            modifier = Modifier.padding(horizontal = 12.dp)
+        )
     }
 }
 

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/EnumColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/EnumColumn.kt
@@ -19,6 +19,7 @@ fun <T : Any, C, E, ENUM : Enum<ENUM>> ReadonlyTableColumnsBuilder<T, C, E>.read
     getTitle: (ENUM) -> String = { it.toString() }
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filterType?.let {
@@ -36,7 +37,7 @@ private fun <T : Any, C, E, ENUM : Enum<ENUM>> ReadonlyColumnBuilder<T, C, E>.re
     cell { item, _ ->
         Text(
             text = getTitle(valueOf(item)),
-            modifier = Modifier.padding(start = 12.dp)
+            modifier = Modifier.padding(horizontal = 12.dp)
         )
     }
 }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/ReadIsActualColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/ReadIsActualColumn.kt
@@ -24,6 +24,7 @@ internal fun <T : Any, C, E> ReadonlyTableColumnsBuilder<T, C, E>.readIsActualCo
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/SelectionColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/SelectionColumn.kt
@@ -2,6 +2,7 @@ package ru.pavlig43.immutable.internal.column
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
@@ -42,7 +43,12 @@ private fun <T : IMultiLineTableUi, C, E : TableData<T>> ReadonlyTableColumnsBui
     column(idKey, valueOf = { it.composeId }) {
         header("Ид")
         align(Alignment.Center)
-        cell { item, _ -> Text(item.composeId.toString()) }
+        cell { item, _ ->
+            Text(
+                text = item.composeId.toString(),
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+        }
         autoWidth(max = 500.dp)
 
     }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/TextColumn.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/column/TextColumn.kt
@@ -17,6 +17,7 @@ fun <T : Any, C, E> ReadonlyTableColumnsBuilder<T, C, E>.readTextColumn(
     filterType: TableFilterType.TextTableFilter? = null
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filterType?.let {
@@ -33,7 +34,7 @@ private fun <T : Any, C, E> ReadonlyColumnBuilder<T, C, E>.readTextCell(
     cell { item, _ ->
         Text(
             text = valueOf(item),
-            modifier = Modifier.padding(start = 12.dp)
+            modifier = Modifier.padding(horizontal = 12.dp)
         )
     }
 }

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/CheckBoxColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/CheckBoxColumn.kt
@@ -19,6 +19,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.writeCheckBoxColumn(
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DateColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DateColumn.kt
@@ -28,6 +28,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.writeDateColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {
@@ -49,6 +50,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.readDateColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DateTimeColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DateTimeColumn.kt
@@ -29,6 +29,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.writeDateTimeColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {
@@ -50,6 +51,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.readDateTimeColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DecimalColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/DecimalColumn.kt
@@ -29,6 +29,7 @@ fun <T : IMultiLineTableUi, C, E> EditableTableColumnsBuilder<T, C, E>.decimalCo
     footerValue: ((E) -> Int)? = null
 ) {
     column(key, valueOf = { getValue(it) }) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filter(
@@ -61,6 +62,7 @@ fun <T : IMultiLineTableUi, C, E> EditableTableColumnsBuilder<T, C, E>.readDecim
     decimalFormat: DecimalFormat,
 ) {
     column(key, valueOf = { getValue(it) }) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         readNumberCell(format = decimalFormat, getCount = { getValue(it) })
@@ -76,6 +78,7 @@ fun <T : IMultiLineTableUi, C, E> EditableTableColumnsBuilder<T, C, E>.readDecim
     footerValue: (E) -> Int
 ) {
     column(key, valueOf = { getValue(it) }) {
+        autoWidth(300.dp)
         header(headerText)
         align(Alignment.CenterStart)
         filter(

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/ItemTypeColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/ItemTypeColumn.kt
@@ -43,6 +43,7 @@ fun <T : Any, C, E, Type : ItemType> EditableTableColumnsBuilder<T, C, E>.writeI
 ) {
     column(column, valueOf = valueOf) {
         header(headerText)
+        autoWidth(300.dp)
         align(alignment)
         filterType?.let {
             filter(it)
@@ -64,6 +65,7 @@ fun <T : Any, C, E, Type : ItemType> EditableTableColumnsBuilder<T, C, E>.readIt
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/SearchColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/SearchColumn.kt
@@ -37,6 +37,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.textWithSearchIconColum
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {
@@ -70,7 +71,7 @@ private fun NameRowWithSearchIcon(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Text(text, Modifier.weight(1f).padding(start = 4.dp))
+        Text(text, Modifier.weight(1f).padding(horizontal = 4.dp))
         ToolTipIconButton(
             tooltipText = "Выбрать",
             onClick = onOpenChooseDialog,

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/SelectionColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/SelectionColumn.kt
@@ -2,6 +2,7 @@ package ru.pavlig43.mutable.api.column
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
@@ -40,7 +41,12 @@ private fun <T : IMultiLineTableUi, C, E : TableData<T>> EditableTableColumnsBui
     column(idKey, valueOf = { it.composeId }) {
         header("Ид")
         align(Alignment.Center)
-        cell { item, _ -> Text(item.composeId.plus(1).toString()) }
+        cell { item, _ ->
+            Text(
+                text = item.composeId.plus(1).toString(),
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+        }
         autoWidth(max = 500.dp)
 
     }

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/TextColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/TextColumn.kt
@@ -22,6 +22,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.writeTextColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {
@@ -44,6 +45,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.readTextColumn(
     alignment: Alignment = Alignment.CenterStart
 ) {
     column(column, valueOf = valueOf) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {

--- a/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/VendorColumn.kt
+++ b/features/table/mutable/src/commonMain/kotlin/ru/pavlig43/mutable/api/column/VendorColumn.kt
@@ -25,6 +25,7 @@ fun <T : Any, C, E> EditableTableColumnsBuilder<T, C, E>.vendorNameColumn(
     alignment: Alignment = Alignment.Center
 ) {
     column(column, valueOf = { it }) {
+        autoWidth(300.dp)
         header(headerText)
         align(alignment)
         filterType?.let {


### PR DESCRIPTION
- Add autoWidth(300.dp) to all text, decimal, date, and enum columns
- Change padding from start-only to horizontal (12.dp left + right)
- Apply changes to immutable, mutable, and flowImmutable table modules
- Improve column width consistency across all tables