### PR TITLE
feat: add priceForSale field to Product entity

### DIFF
--- a/database/schemas/ru.pavlig43.database.NocombroDatabase/1.json
+++ b/database/schemas/ru.pavlig43.database.NocombroDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "23ff40f3f83df9bf289bd540e44cb7ef",
+    "identityHash": "3351a4624b8b8e9e21cbc9d311623a25",
     "entities": [
       {
         "tableName": "file",
@@ -198,7 +198,7 @@
       },
       {
         "tableName": "product",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `display_name` TEXT NOT NULL, `created_at` TEXT NOT NULL, `comment` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `display_name` TEXT NOT NULL, `created_at` TEXT NOT NULL, `comment` TEXT NOT NULL, `price_for_sale` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
         "fields": [
           {
             "fieldPath": "type",
@@ -222,6 +222,12 @@
             "fieldPath": "comment",
             "columnName": "comment",
             "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceForSale",
+            "columnName": "price_for_sale",
+            "affinity": "INTEGER",
             "notNull": true
           },
           {
@@ -820,7 +826,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '23ff40f3f83df9bf289bd540e44cb7ef')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3351a4624b8b8e9e21cbc9d311623a25')"
     ]
   }
 }

--- a/database/src/commonMain/kotlin/ru/pavlig43/database/data/product/Product.kt
+++ b/database/src/commonMain/kotlin/ru/pavlig43/database/data/product/Product.kt
@@ -26,6 +26,9 @@ data class Product(
 
     val comment: String = "",
 
+    @ColumnInfo("price_for_sale")
+    val priceForSale: Int = 0,
+
     @PrimaryKey(autoGenerate = true)
     override val id: Int = 0,
 ) : SingleItem

--- a/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/ProductField.kt
+++ b/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/ProductField.kt
@@ -7,6 +7,8 @@ internal enum class ProductField {
     DISPLAY_NAME,
     /** Тип продукта */
     PRODUCT_TYPE,
+    /** Рекомендованная цена продажи */
+    PRICE_FOR_SALE,
     /** Дата создания */
     CREATED_AT,
     /** Комментарий */

--- a/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/create/component/Column.kt
+++ b/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/create/component/Column.kt
@@ -2,6 +2,8 @@ package ru.pavlig43.product.internal.create.component
 
 import kotlinx.collections.immutable.ImmutableList
 import ru.pavlig43.database.data.product.ProductType
+import ru.pavlig43.mutable.api.column.DecimalFormat
+import ru.pavlig43.mutable.api.column.decimalColumn
 import ru.pavlig43.mutable.api.column.writeDateColumn
 import ru.pavlig43.mutable.api.column.writeItemTypeColumn
 import ru.pavlig43.mutable.api.column.writeTextColumn
@@ -43,6 +45,15 @@ internal fun createProductColumns0(
                 options = ProductType.entries,
                 isSortable = false,
                 onTypeSelected = { item, type -> onChangeItem { it.copy(productType = type) } }
+            )
+
+            decimalColumn(
+                key = ProductField.PRICE_FOR_SALE,
+                getValue = { it.priceForSale },
+                headerText = "Цена продажи (₽)",
+                decimalFormat = DecimalFormat.Decimal2(),
+                updateItem = { item, newPrice -> onChangeItem { it.copy(priceForSale = newPrice) } },
+                isSortable = false
             )
 
             // Дата создания

--- a/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/model/ProductEssentialsUi.kt
+++ b/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/model/ProductEssentialsUi.kt
@@ -16,6 +16,8 @@ internal data class ProductEssentialsUi(
 
     val comment: String = "",
 
+    val priceForSale: Int = 0,
+
     val id: Int = 0,
 ) : ISingleLineTableUi
 
@@ -26,6 +28,7 @@ internal fun ProductEssentialsUi.toDto(): Product {
         displayName = displayName,
         createdAt = createdAt,
         comment = comment,
+        priceForSale = priceForSale,
         id = id
     )
 }
@@ -36,6 +39,7 @@ internal fun Product.toUi(): ProductEssentialsUi {
         productType = type,
         createdAt = createdAt,
         comment = comment,
+        priceForSale = priceForSale,
         id = id
     )
 }

--- a/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/update/tabs/essential/Column.kt
+++ b/features/form/product/src/commonMain/kotlin/ru/pavlig43/product/internal/update/tabs/essential/Column.kt
@@ -1,6 +1,8 @@
 package ru.pavlig43.product.internal.update.tabs.essential
 
 import kotlinx.collections.immutable.ImmutableList
+import ru.pavlig43.mutable.api.column.DecimalFormat
+import ru.pavlig43.mutable.api.column.decimalColumn
 import ru.pavlig43.mutable.api.column.readItemTypeColumn
 import ru.pavlig43.mutable.api.column.writeDateColumn
 import ru.pavlig43.mutable.api.column.writeTextColumn
@@ -42,6 +44,15 @@ internal fun createProductColumns1(
                 column = ProductField.PRODUCT_TYPE,
                 valueOf = { it.productType },
                 isSortable = false,
+            )
+
+            decimalColumn(
+                key = ProductField.PRICE_FOR_SALE,
+                getValue = { it.priceForSale },
+                headerText = "Цена продажи (₽)",
+                decimalFormat = DecimalFormat.Decimal2(),
+                updateItem = { item, newPrice -> onChangeItem { it.copy(priceForSale = newPrice) } },
+                isSortable = false
             )
 
             writeDateColumn(

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/Columns.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/Columns.kt
@@ -4,8 +4,10 @@ package ru.pavlig43.immutable.internal.component.items.product
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import ru.pavlig43.database.data.product.ProductType
+import ru.pavlig43.immutable.internal.column.DecimalFormat
 import ru.pavlig43.immutable.internal.column.idWithSelection
 import ru.pavlig43.immutable.internal.column.readDateColumn
+import ru.pavlig43.immutable.internal.column.readDecimalColumn
 import ru.pavlig43.immutable.internal.column.readEnumColumn
 import ru.pavlig43.immutable.internal.column.readTextColumn
 import ru.pavlig43.immutable.internal.component.ImmutableTableUiEvent
@@ -22,7 +24,7 @@ internal enum class ProductField {
     NAME,
     TYPE,
     CREATED_AT,
-    COMMENT
+    COMMENT,
 }
 @Suppress("LongMethod")
 internal fun createProductColumn(
@@ -68,6 +70,7 @@ internal fun createProductColumn(
                 valueOf = { it.comment },
                 filterType = TableFilterType.TextTableFilter()
             )
+
         }
     return columns
 

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/ProductTableComponent.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/ProductTableComponent.kt
@@ -36,6 +36,7 @@ private fun Product.toUi(): ProductTableUi {
         displayName = displayName,
         type = type,
         createdAt = createdAt,
-        comment = comment
+        comment = comment,
+        priceForSale = priceForSale
     )
 }

--- a/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/ProductTableUi.kt
+++ b/features/table/immutable/src/commonMain/kotlin/ru/pavlig43/immutable/internal/component/items/product/ProductTableUi.kt
@@ -10,4 +10,6 @@ data class ProductTableUi(
     val type: ProductType,
     val createdAt: LocalDate,
     val comment: String = "",
+
+    val priceForSale: Int = 0,
 ) : IMultiLineTableUi


### PR DESCRIPTION
Add recommended sale price field (stored in kopecks as Int):
- Database: add priceForSale column to Product entity
- UI models: add field to ProductEssentialsUi and ProductTableUi
- Create form: add editable decimal column
- Update form: add editable decimal column
- Immutable table: add read-only decimal column with filter
- Filter/Sort: add PRICE_FOR_SALE support