### PR TITLE
Optimize mirror synchronization status

### DIFF
--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/SyncService.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/SyncService.kt
@@ -8,6 +8,7 @@ import ru.pavlig43.database.data.files.remote.RemoteFileBatchDownloadRepository
 import ru.pavlig43.database.data.files.remote.RemoteFileBatchDownloadSummary
 import ru.pavlig43.database.data.sync.mirror.MirrorReconciliationService
 import java.io.File
+import kotlin.time.TimeSource
 
 /**
  * Прикладной facade синхронизации для UI и root-компонентов.
@@ -68,22 +69,40 @@ class SyncService(
      * Итог включает результат восстановления файлов, выполненного после pull.
      */
     suspend fun syncOnce(): SyncRunResult {
-        val pushResult = pushOnce()
-        if (pushResult.error != null) {
-            return pushResult
+        val context = mirrorReconciliationService.prepareSync().getOrElse { throwable ->
+            return failureWithoutRefresh(throwable.message ?: "Mirror sync preparation failed")
+        }
+        val mirrorRun = mirrorReconciliationService.executePreparedSync(context).getOrElse { throwable ->
+            return failureWithoutRefresh(throwable.message ?: "Mirror sync failed")
         }
 
-        val pullResult = pullOnce()
-        if (pullResult.error != null) {
-            return pullResult
-        }
+        syncStateRepository.updateLastPushAt(mirrorRun.completedAt)
+        syncStateRepository.updateLastPullAt(mirrorRun.completedAt)
+        val status = SyncStatusSnapshot(
+            pendingLocalChangesCount = 0,
+            remoteChangesCount = 0,
+            hasRemoteChanges = false,
+            remoteSyncConfigured = true,
+            lastStatusCheckAt = mirrorRun.completedAt,
+            lastSyncAt = mirrorRun.completedAt,
+            lastPullAt = mirrorRun.completedAt,
+        ).also { _status.value = it }
 
+        val recoveryMark = TimeSource.Monotonic.markNow()
+        val filesDownloadSummary = downloadMissingFilesAfterMirrorPull().getOrElse { throwable ->
+            SyncFacadeStageLog.completed("S3 recovery", recoveryMark.elapsedNow().inWholeMilliseconds)
+            return SyncRunResult.failure(
+                message = throwable.message ?: "File recovery after mirror pull failed",
+                status = status,
+            )
+        }
+        SyncFacadeStageLog.completed("S3 recovery", recoveryMark.elapsedNow().inWholeMilliseconds)
         return SyncRunResult(
-            status = pullResult.status,
-            lastSyncAt = pushResult.lastSyncAt ?: pullResult.lastSyncAt,
-            lastPushAt = pushResult.lastPushAt,
-            lastPullAt = pullResult.lastPullAt,
-            filesDownloadSummary = pullResult.filesDownloadSummary,
+            status = status,
+            lastSyncAt = mirrorRun.completedAt,
+            lastPushAt = mirrorRun.completedAt,
+            lastPullAt = mirrorRun.completedAt,
+            filesDownloadSummary = filesDownloadSummary,
         )
     }
 
@@ -168,6 +187,30 @@ class SyncService(
             return Result.success(null)
         }
         return repository.downloadMissingLocalCopies()
+    }
+
+    private suspend fun failureWithoutRefresh(message: String): SyncRunResult {
+        val current = _status.value
+        val syncState = syncStateRepository.getSyncState()
+        return SyncRunResult.failure(
+            message = message,
+            status = current ?: SyncStatusSnapshot(
+                pendingLocalChangesCount = 0,
+                remoteChangesCount = 0,
+                hasRemoteChanges = false,
+                remoteSyncConfigured = false,
+                lastStatusCheckAt = defaultUpdatedAt(),
+                lastSyncAt = syncState?.lastPushAt,
+                lastPullAt = syncState?.lastPullAt,
+            ),
+        )
+    }
+}
+
+private object SyncFacadeStageLog {
+    private val logger = java.util.logging.Logger.getLogger("MirrorSync")
+    fun completed(stage: String, milliseconds: Long) {
+        logger.info("Mirror sync stage=$stage durationMs=$milliseconds")
     }
 }
 

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/SyncService.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/SyncService.kt
@@ -7,6 +7,7 @@ import kotlinx.datetime.LocalDateTime
 import ru.pavlig43.database.data.files.remote.RemoteFileBatchDownloadRepository
 import ru.pavlig43.database.data.files.remote.RemoteFileBatchDownloadSummary
 import ru.pavlig43.database.data.sync.mirror.MirrorReconciliationService
+import ru.pavlig43.database.data.sync.mirror.MirrorRemoteStatus
 import java.io.File
 import kotlin.time.TimeSource
 
@@ -70,19 +71,28 @@ class SyncService(
      */
     suspend fun syncOnce(): SyncRunResult {
         val context = mirrorReconciliationService.prepareSync().getOrElse { throwable ->
-            return failureWithoutRefresh(throwable.message ?: "Mirror sync preparation failed")
+            val configuration = runCatching {
+                mirrorReconciliationService.getConfigurationStatus()
+            }.getOrNull()
+            return failureWithoutRefresh(
+                message = throwable.message ?: "Mirror sync preparation failed",
+                configuration = configuration,
+            )
         }
         val mirrorRun = mirrorReconciliationService.executePreparedSync(context).getOrElse { throwable ->
-            return failureWithoutRefresh(throwable.message ?: "Mirror sync failed")
+            return failureWithoutRefresh(
+                message = throwable.message ?: "Mirror sync failed",
+                configuration = context.configuration,
+            )
         }
 
         syncStateRepository.updateLastPushAt(mirrorRun.completedAt)
         syncStateRepository.updateLastPullAt(mirrorRun.completedAt)
         val status = SyncStatusSnapshot(
-            pendingLocalChangesCount = 0,
-            remoteChangesCount = 0,
-            hasRemoteChanges = false,
-            remoteSyncConfigured = true,
+            pendingLocalChangesCount = mirrorRun.remainingPushChanges,
+            remoteChangesCount = mirrorRun.remainingPullChanges,
+            hasRemoteChanges = mirrorRun.remainingPullChanges > 0,
+            remoteSyncConfigured = context.configuration.configured,
             lastStatusCheckAt = mirrorRun.completedAt,
             lastSyncAt = mirrorRun.completedAt,
             lastPullAt = mirrorRun.completedAt,
@@ -189,20 +199,29 @@ class SyncService(
         return repository.downloadMissingLocalCopies()
     }
 
-    private suspend fun failureWithoutRefresh(message: String): SyncRunResult {
+    private suspend fun failureWithoutRefresh(
+        message: String,
+        configuration: MirrorRemoteStatus?,
+    ): SyncRunResult {
         val current = _status.value
         val syncState = syncStateRepository.getSyncState()
+        val status = (current ?: SyncStatusSnapshot(
+            pendingLocalChangesCount = 0,
+            remoteChangesCount = 0,
+            hasRemoteChanges = false,
+            remoteSyncConfigured = configuration?.configured ?: false,
+            lastStatusCheckAt = configuration?.checkedAt ?: defaultUpdatedAt(),
+            lastSyncAt = syncState?.lastPushAt,
+            lastPullAt = syncState?.lastPullAt,
+        )).copy(
+            remoteSyncConfigured = configuration?.configured ?: current?.remoteSyncConfigured ?: false,
+            lastStatusCheckAt = configuration?.checkedAt ?: current?.lastStatusCheckAt ?: defaultUpdatedAt(),
+            remoteError = message,
+        )
+        _status.value = status
         return SyncRunResult.failure(
             message = message,
-            status = current ?: SyncStatusSnapshot(
-                pendingLocalChangesCount = 0,
-                remoteChangesCount = 0,
-                hasRemoteChanges = false,
-                remoteSyncConfigured = false,
-                lastStatusCheckAt = defaultUpdatedAt(),
-                lastSyncAt = syncState?.lastPushAt,
-                lastPullAt = syncState?.lastPullAt,
-            ),
+            status = status,
         )
     }
 }

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorLocalApplyRepository.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorLocalApplyRepository.kt
@@ -27,9 +27,12 @@ class MirrorLocalApplyRepository(
             val explicitTombstones = changes.filter { it.row.deletedAt != null }
             var persistedTombstones = persistNewestTombstones(explicitTombstones)
 
-            for (change in changes.filter { it.row.deletedAt == null }.sortedBy { it.table.applyOrder }) {
-                applyActiveChange(change)
-            }
+            changes.filter { it.row.deletedAt == null }
+                .groupBy(MirrorPushEntityChange::table)
+                .toSortedMap(compareBy(MirrorSyncTable::applyOrder))
+                .forEach { (table, tableChanges) ->
+                    applyActiveChanges(table, tableChanges)
+                }
 
             val explicitKeys = explicitTombstones
                 .mapTo(mutableSetOf()) { it.entityKey() }
@@ -73,11 +76,14 @@ class MirrorLocalApplyRepository(
         )
     }
 
-    private suspend fun applyActiveChange(change: MirrorPushEntityChange) {
-        if (change.table == MirrorSyncTable.BATCH_COST_PRICE) {
-            applyBatchCostPrice(change.row as BatchCostPriceMirrorRow)
+    private suspend fun applyActiveChanges(
+        table: MirrorSyncTable,
+        changes: List<MirrorPushEntityChange>,
+    ) {
+        if (table == MirrorSyncTable.BATCH_COST_PRICE) {
+            changes.forEach { applyBatchCostPrice(it.row as BatchCostPriceMirrorRow) }
         } else {
-            entityApplyRepository.applyChanges(listOf(change))
+            entityApplyRepository.applyChanges(changes)
         }
     }
 

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorReconciliationService.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorReconciliationService.kt
@@ -24,6 +24,9 @@ class MirrorReconciliationService(
     /** Возвращает низкоуровневый статус remote gateway без загрузки snapshot. */
     suspend fun getStatus(): MirrorRemoteStatus = remoteGateway.getStatus()
 
+    /** Returns the cheap local configuration status without probing remote tables. */
+    suspend fun getConfigurationStatus(): MirrorRemoteStatus = remoteGateway.getConfigurationStatus()
+
     suspend fun prepareSync(): Result<MirrorPreparedSyncContext> = runCatching {
         val configuration = remoteGateway.getConfigurationStatus()
         require(configuration.configured) { configuration.error ?: "Mirror sync is not configured" }
@@ -50,11 +53,16 @@ class MirrorReconciliationService(
         val applyMark = TimeSource.Monotonic.markNow()
         localApplyRepository.apply(context.plan.pullChanges)
         SyncStageLog.completed("Room apply", applyMark.elapsedNow().inWholeMilliseconds)
+        val refreshedLocal = localSnapshotRepository.loadSnapshot(MirrorSyncTable.mirroredBusinessTables)
+        val expectedRemote = context.remoteSnapshot.withAppliedChanges(context.plan.pushChanges)
+        val remainingPlan = planner.plan(refreshedLocal, expectedRemote)
         MirrorReconciliationRun(
             configured = true,
             completedAt = context.remoteSnapshot.loadedAt,
             pushedChanges = context.plan.pushChanges.size,
             pulledChanges = context.plan.pullChanges.size,
+            remainingPushChanges = remainingPlan.pushChanges.size,
+            remainingPullChanges = remainingPlan.pullChanges.size,
         )
     }
 
@@ -210,6 +218,8 @@ data class MirrorReconciliationRun(
     val completedAt: LocalDateTime,
     val pushedChanges: Int,
     val pulledChanges: Int,
+    val remainingPushChanges: Int = 0,
+    val remainingPullChanges: Int = 0,
 ) {
     companion object {
         /** Создает успешный no-op результат для установки без remote-конфигурации. */
@@ -220,6 +230,22 @@ data class MirrorReconciliationRun(
             pulledChanges = 0,
         )
     }
+}
+
+private fun MirrorRemoteSnapshot.withAppliedChanges(
+    changes: List<MirrorPushEntityChange>,
+): MirrorRemoteSnapshot {
+    if (changes.isEmpty()) return this
+
+    val changesByTable = changes.groupBy(MirrorPushEntityChange::table)
+    return copy(
+        rowsByTable = rowsByTable + changesByTable.mapValues { (table, tableChanges) ->
+            val rowsBySyncId = rowsByTable[table].orEmpty()
+                .associateByTo(linkedMapOf(), MirrorSyncRow::syncId)
+            tableChanges.forEach { change -> rowsBySyncId[change.row.syncId] = change.row }
+            rowsBySyncId.values.toList()
+        },
+    )
 }
 
 /** Статистика полной пересборки remote mirror из локального snapshot. */

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorReconciliationService.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorReconciliationService.kt
@@ -2,6 +2,7 @@ package ru.pavlig43.database.data.sync.mirror
 
 import kotlinx.datetime.LocalDateTime
 import ru.pavlig43.database.data.sync.defaultUpdatedAt
+import kotlin.time.TimeSource
 
 /**
  * Координирует snapshot-based reconciliation между Room и remote mirror.
@@ -23,11 +24,45 @@ class MirrorReconciliationService(
     /** Возвращает низкоуровневый статус remote gateway без загрузки snapshot. */
     suspend fun getStatus(): MirrorRemoteStatus = remoteGateway.getStatus()
 
+    suspend fun prepareSync(): Result<MirrorPreparedSyncContext> = runCatching {
+        val configuration = remoteGateway.getConfigurationStatus()
+        require(configuration.configured) { configuration.error ?: "Mirror sync is not configured" }
+        require(configuration.error == null) { configuration.error ?: "Mirror remote is unavailable" }
+
+        val local = localSnapshotRepository.loadSnapshot(MirrorSyncTable.mirroredBusinessTables)
+        val remoteMark = TimeSource.Monotonic.markNow()
+        val remote = remoteGateway.loadRemoteSnapshot().getOrElse { throw stageFailure("remote snapshot", it) }
+        SyncStageLog.completed("remote snapshot", remoteMark.elapsedNow().inWholeMilliseconds)
+        val plannerMark = TimeSource.Monotonic.markNow()
+        val plan = planner.plan(local, remote)
+        SyncStageLog.completed("planner", plannerMark.elapsedNow().inWholeMilliseconds)
+        MirrorPreparedSyncContext(configuration, local, remote, plan)
+    }
+
+    suspend fun executePreparedSync(context: MirrorPreparedSyncContext): Result<MirrorReconciliationRun> = runCatching {
+        val pushMark = TimeSource.Monotonic.markNow()
+        if (context.plan.pushChanges.isNotEmpty()) {
+            remoteGateway.pushMirrorState(context.plan.pushChanges)
+                .getOrElse { throw stageFailure("push", it) }
+        }
+        SyncStageLog.completed("push", pushMark.elapsedNow().inWholeMilliseconds)
+
+        val applyMark = TimeSource.Monotonic.markNow()
+        localApplyRepository.apply(context.plan.pullChanges)
+        SyncStageLog.completed("Room apply", applyMark.elapsedNow().inWholeMilliseconds)
+        MirrorReconciliationRun(
+            configured = true,
+            completedAt = context.remoteSnapshot.loadedAt,
+            pushedChanges = context.plan.pushChanges.size,
+            pulledChanges = context.plan.pullChanges.size,
+        )
+    }
+
     /**
      * Загружает локальный и удаленный snapshot и строит план без изменения данных.
      */
     suspend fun buildPreview(): Result<MirrorReconciliationPreview> = runCatching {
-        val status = remoteGateway.getStatus()
+        val status = remoteGateway.getConfigurationStatus()
         require(status.configured) { status.error ?: "Mirror sync is not configured" }
         require(status.error == null) { status.error ?: "Mirror remote is unavailable" }
 
@@ -77,7 +112,7 @@ class MirrorReconciliationService(
      * сравнения, но не применяет их локально.
      */
     suspend fun pushLocalWinners(): Result<MirrorReconciliationRun> = runCatching {
-        val status = remoteGateway.getStatus()
+        val status = remoteGateway.getConfigurationStatus()
         if (!status.configured) return@runCatching MirrorReconciliationRun.skipped(status.checkedAt)
         require(status.error == null) { status.error ?: "Mirror remote is unavailable" }
 
@@ -102,7 +137,7 @@ class MirrorReconciliationService(
      * предварительным сохранением remote tombstone в deletion journal.
      */
     suspend fun pullRemoteWinners(): Result<MirrorReconciliationRun> = runCatching {
-        val status = remoteGateway.getStatus()
+        val status = remoteGateway.getConfigurationStatus()
         if (!status.configured) return@runCatching MirrorReconciliationRun.skipped(status.checkedAt)
         require(status.error == null) { status.error ?: "Mirror remote is unavailable" }
 
@@ -126,7 +161,7 @@ class MirrorReconciliationService(
      * временем [MirrorRemoteRebuildResult.rebuiltAt].
      */
     suspend fun rebuildRemoteFromLocal(): Result<MirrorRemoteRebuildResult> = runCatching {
-        val status = remoteGateway.getStatus()
+        val status = remoteGateway.getConfigurationStatus()
         require(status.configured) { status.error ?: "Mirror sync is not configured" }
         require(status.error == null) { status.error ?: "Mirror remote is unavailable" }
 
@@ -149,6 +184,23 @@ class MirrorReconciliationService(
             pushedRows = localChanges.size,
             tombstonedRows = tombstones.size,
         )
+    }
+}
+
+data class MirrorPreparedSyncContext(
+    val configuration: MirrorRemoteStatus,
+    val localSnapshot: MirrorLocalSnapshot,
+    val remoteSnapshot: MirrorRemoteSnapshot,
+    val plan: MirrorReconciliationPlan,
+)
+
+private fun stageFailure(stage: String, throwable: Throwable): IllegalStateException =
+    IllegalStateException("Mirror $stage failed: ${throwable.message ?: throwable::class.simpleName}", throwable)
+
+private object SyncStageLog {
+    private val logger = java.util.logging.Logger.getLogger("MirrorSync")
+    fun completed(stage: String, milliseconds: Long) {
+        logger.info("Mirror sync stage=$stage durationMs=$milliseconds")
     }
 }
 

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorSyncContracts.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/MirrorSyncContracts.kt
@@ -15,6 +15,9 @@ import kotlinx.datetime.LocalDateTime
  * ошибки доступности и сообщает их через [MirrorRemoteStatus.error].
  */
 interface MirrorSyncRemoteGateway {
+    /** Cheap local configuration check. It must not connect or probe mirror tables. */
+    suspend fun getConfigurationStatus(): MirrorRemoteStatus = getStatus()
+
     /**
      * Проверяет конфигурацию и доступность remote mirror.
      *

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/NoopMirrorSyncRemoteGateway.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/NoopMirrorSyncRemoteGateway.kt
@@ -9,6 +9,8 @@ import ru.pavlig43.database.data.sync.defaultUpdatedAt
  * молчаливого no-op, чтобы вызывающий код не считал синхронизацию успешной.
  */
 class NoopMirrorSyncRemoteGateway : MirrorSyncRemoteGateway {
+    override suspend fun getConfigurationStatus() = getStatus()
+
     override suspend fun getStatus() = MirrorRemoteStatus(
         configured = false,
         availableTables = emptySet(),

--- a/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/YdbJdbcMirrorSyncGateway.kt
+++ b/database/src/desktopMain/kotlin/ru/pavlig43/database/data/sync/mirror/YdbJdbcMirrorSyncGateway.kt
@@ -4,6 +4,7 @@ import ru.pavlig43.database.data.sync.defaultUpdatedAt
 import java.sql.Connection
 import java.sql.DriverManager
 import java.util.Properties
+import kotlin.time.TimeSource
 
 /**
  * JDBC-реализация typed mirror gateway для YDB.
@@ -18,6 +19,12 @@ import java.util.Properties
 class YdbJdbcMirrorSyncGateway(
     private val config: YdbMirrorJdbcConfig,
 ) : MirrorSyncRemoteGateway {
+    override suspend fun getConfigurationStatus() = MirrorRemoteStatus(
+        configured = true,
+        availableTables = emptySet(),
+        checkedAt = defaultUpdatedAt(),
+    )
+
     /**
      * Проверяет соединение и доступность всех поддерживаемых typed tables.
      *
@@ -204,6 +211,13 @@ class YdbJdbcMirrorSyncGateway(
                     ?.let { setProperty("token", it) }
             }
         }
-        return DriverManager.getConnection(config.jdbcUrl, properties).use(block)
+        val connectionMark = TimeSource.Monotonic.markNow()
+        val connection = DriverManager.getConnection(config.jdbcUrl, properties)
+        LOGGER.info("Mirror sync stage=connection durationMs=${connectionMark.elapsedNow().inWholeMilliseconds}")
+        return connection.use(block)
+    }
+
+    private companion object {
+        val LOGGER: java.util.logging.Logger = java.util.logging.Logger.getLogger("MirrorSync")
     }
 }

--- a/database/src/desktopTest/kotlin/ru/pavlig43/database/SyncServiceMirrorStatusTest.kt
+++ b/database/src/desktopTest/kotlin/ru/pavlig43/database/SyncServiceMirrorStatusTest.kt
@@ -50,9 +50,10 @@ class SyncServiceMirrorStatusTest : DesktopMainDispatcherFunSpec({
     test("syncOnce returns the file download summary produced after mirror pull") {
         withEmptyTestDatabase { db ->
             db.syncStateDao.upsertSyncState(SyncStateEntity())
+            val gateway = StatusMirrorGateway(LocalDateTime(2026, 6, 11, 15, 0))
             val service = createSyncService(
                 db = db,
-                gateway = StatusMirrorGateway(LocalDateTime(2026, 6, 11, 15, 0)),
+                gateway = gateway,
                 fileRepository = RemoteFileBatchDownloadRepository(
                     db = db,
                     remoteFileStorageGateway = ConfiguredFileStorageGateway(),
@@ -63,6 +64,9 @@ class SyncServiceMirrorStatusTest : DesktopMainDispatcherFunSpec({
 
             result.error shouldBe null
             result.filesDownloadSummary?.scannedCount shouldBe 0
+            gateway.configurationStatusCalls shouldBe 1
+            gateway.statusCalls shouldBe 0
+            gateway.snapshotCalls shouldBe 1
         }
     }
 
@@ -91,6 +95,24 @@ class SyncServiceMirrorStatusTest : DesktopMainDispatcherFunSpec({
             gateway.pullCalls shouldBe 0
             fileGateway.downloadCalls shouldBe 0
             db.syncStateDao.getSyncState() shouldBe initialState
+        }
+    }
+
+    test("fresh Room restores 150 remote rows from one remote snapshot") {
+        withEmptyTestDatabase { db ->
+            db.syncStateDao.upsertSyncState(SyncStateEntity())
+            val gateway = StatusMirrorGateway(
+                checkedAt = LocalDateTime(2026, 6, 11, 15, 0),
+                remoteRowCount = 150,
+            )
+
+            val result = createSyncService(db, gateway).syncOnce()
+
+            result.error shouldBe null
+            db.vendorDao.getAll().size shouldBe 150
+            gateway.configurationStatusCalls shouldBe 1
+            gateway.statusCalls shouldBe 0
+            gateway.snapshotCalls shouldBe 1
         }
     }
 })
@@ -134,32 +156,50 @@ private class ConfiguredFileStorageGateway : RemoteFileStorageGateway {
 
 private class StatusMirrorGateway(
     private val checkedAt: LocalDateTime,
+    remoteRowCount: Int = 1,
 ) : MirrorSyncRemoteGateway {
+    var configurationStatusCalls = 0
+    var statusCalls = 0
+    var snapshotCalls = 0
     var pushCalls = 0
     var pullCalls = 0
-    private val remoteRow = VendorMirrorRow(
-        syncId = "remote-vendor",
-        displayName = "Remote vendor",
-        comment = "",
-        updatedAt = checkedAt,
-    )
+    private val remoteRows = List(remoteRowCount) { index ->
+        VendorMirrorRow(
+            syncId = "remote-vendor-$index",
+            displayName = "Remote vendor $index",
+            comment = "",
+            updatedAt = checkedAt,
+        )
+    }
 
-    override suspend fun getStatus() = MirrorRemoteStatus(
+    override suspend fun getConfigurationStatus(): MirrorRemoteStatus {
+        configurationStatusCalls++
+        return remoteStatus()
+    }
+
+    override suspend fun getStatus(): MirrorRemoteStatus {
+        statusCalls++
+        return remoteStatus()
+    }
+
+    private fun remoteStatus() = MirrorRemoteStatus(
         configured = true,
         availableTables = MirrorSyncTable.mirroredBusinessTables
             .mapTo(mutableSetOf(), MirrorSyncTable::tableName),
         checkedAt = checkedAt,
     )
 
-    override suspend fun loadRemoteSnapshot(tables: List<MirrorSyncTable>) =
-        Result.success(
+    override suspend fun loadRemoteSnapshot(tables: List<MirrorSyncTable>): Result<MirrorRemoteSnapshot> {
+        snapshotCalls++
+        return Result.success(
             MirrorRemoteSnapshot(
                 loadedAt = checkedAt,
                 rowsByTable = tables.associateWith { table ->
-                    if (table == MirrorSyncTable.VENDOR) listOf(remoteRow) else emptyList()
+                    if (table == MirrorSyncTable.VENDOR) remoteRows else emptyList()
                 },
             )
         )
+    }
 
     override suspend fun pushMirrorState(changes: List<MirrorPushEntityChange>): Result<MirrorPushResult> {
         pushCalls++
@@ -173,7 +213,7 @@ private class StatusMirrorGateway(
                 pulledAt = checkedAt,
                 changes = request.tables.flatMap { table ->
                     if (table == MirrorSyncTable.VENDOR) {
-                        listOf(MirrorPushEntityChange(table, remoteRow))
+                        remoteRows.map { MirrorPushEntityChange(table, it) }
                     } else {
                         emptyList()
                     }

--- a/database/src/desktopTest/kotlin/ru/pavlig43/database/SyncServiceMirrorStatusTest.kt
+++ b/database/src/desktopTest/kotlin/ru/pavlig43/database/SyncServiceMirrorStatusTest.kt
@@ -24,6 +24,7 @@ import ru.pavlig43.database.data.sync.mirror.MirrorRemoteStatus
 import ru.pavlig43.database.data.sync.mirror.MirrorSyncRemoteGateway
 import ru.pavlig43.database.data.sync.mirror.MirrorSyncTable
 import ru.pavlig43.database.data.sync.mirror.VendorMirrorRow
+import ru.pavlig43.database.data.vendor.Vendor
 import ru.pavlig43.testkit.DesktopMainDispatcherFunSpec
 import ru.pavlig43.testkit.database.withEmptyTestDatabase
 import java.nio.file.Files
@@ -67,6 +68,8 @@ class SyncServiceMirrorStatusTest : DesktopMainDispatcherFunSpec({
             gateway.configurationStatusCalls shouldBe 1
             gateway.statusCalls shouldBe 0
             gateway.snapshotCalls shouldBe 1
+            result.status.pendingLocalChangesCount shouldBe 0
+            result.status.remoteChangesCount shouldBe 0
         }
     }
 
@@ -113,6 +116,69 @@ class SyncServiceMirrorStatusTest : DesktopMainDispatcherFunSpec({
             gateway.configurationStatusCalls shouldBe 1
             gateway.statusCalls shouldBe 0
             gateway.snapshotCalls shouldBe 1
+            result.status.pendingLocalChangesCount shouldBe 0
+            result.status.remoteChangesCount shouldBe 0
+        }
+    }
+
+    test("local row created while remote snapshot loads remains pending for push") {
+        withEmptyTestDatabase { db ->
+            db.syncStateDao.upsertSyncState(SyncStateEntity())
+            val checkedAt = LocalDateTime(2026, 6, 11, 15, 0)
+            val gateway = StatusMirrorGateway(
+                checkedAt = checkedAt,
+                remoteRowCount = 0,
+                onSnapshotLoad = {
+                    db.vendorDao.create(
+                        Vendor(
+                            displayName = "Concurrent vendor",
+                            updatedAt = LocalDateTime(2026, 6, 11, 15, 1),
+                        )
+                    )
+                },
+            )
+
+            val result = createSyncService(db, gateway).syncOnce()
+
+            result.error shouldBe null
+            result.status.pendingLocalChangesCount shouldBe 1
+            result.status.remoteChangesCount shouldBe 0
+            gateway.snapshotCalls shouldBe 1
+            gateway.pushCalls shouldBe 0
+        }
+    }
+
+    test("remote snapshot failure preserves configured YDB status and error") {
+        withEmptyTestDatabase { db ->
+            db.syncStateDao.upsertSyncState(SyncStateEntity())
+            val gateway = StatusMirrorGateway(
+                checkedAt = LocalDateTime(2026, 6, 11, 15, 0),
+                snapshotError = "snapshot unavailable",
+            )
+
+            val result = createSyncService(db, gateway).syncOnce()
+
+            result.error shouldBe "Mirror remote snapshot failed: snapshot unavailable"
+            result.status.remoteSyncConfigured shouldBe true
+            result.status.remoteError shouldBe result.error
+            gateway.snapshotCalls shouldBe 1
+        }
+    }
+
+    test("missing YDB configuration remains unconfigured after sync failure") {
+        withEmptyTestDatabase { db ->
+            db.syncStateDao.upsertSyncState(SyncStateEntity())
+            val gateway = StatusMirrorGateway(
+                checkedAt = LocalDateTime(2026, 6, 11, 15, 0),
+                configured = false,
+            )
+
+            val result = createSyncService(db, gateway).syncOnce()
+
+            result.error shouldBe "Mirror sync is not configured"
+            result.status.remoteSyncConfigured shouldBe false
+            result.status.remoteError shouldBe result.error
+            gateway.snapshotCalls shouldBe 0
         }
     }
 })
@@ -157,6 +223,9 @@ private class ConfiguredFileStorageGateway : RemoteFileStorageGateway {
 private class StatusMirrorGateway(
     private val checkedAt: LocalDateTime,
     remoteRowCount: Int = 1,
+    private val configured: Boolean = true,
+    private val snapshotError: String? = null,
+    private val onSnapshotLoad: suspend () -> Unit = {},
 ) : MirrorSyncRemoteGateway {
     var configurationStatusCalls = 0
     var statusCalls = 0
@@ -183,14 +252,19 @@ private class StatusMirrorGateway(
     }
 
     private fun remoteStatus() = MirrorRemoteStatus(
-        configured = true,
-        availableTables = MirrorSyncTable.mirroredBusinessTables
-            .mapTo(mutableSetOf(), MirrorSyncTable::tableName),
+        configured = configured,
+        availableTables = if (configured) {
+            MirrorSyncTable.mirroredBusinessTables.mapTo(mutableSetOf(), MirrorSyncTable::tableName)
+        } else {
+            emptySet()
+        },
         checkedAt = checkedAt,
     )
 
     override suspend fun loadRemoteSnapshot(tables: List<MirrorSyncTable>): Result<MirrorRemoteSnapshot> {
         snapshotCalls++
+        snapshotError?.let { return Result.failure(IllegalStateException(it)) }
+        onSnapshotLoad()
         return Result.success(
             MirrorRemoteSnapshot(
                 loadedAt = checkedAt,

--- a/database/src/desktopTest/kotlin/ru/pavlig43/database/YdbMirrorIntegrationTest.kt
+++ b/database/src/desktopTest/kotlin/ru/pavlig43/database/YdbMirrorIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import ru.pavlig43.database.data.product.ProductType
@@ -163,19 +164,26 @@ class YdbMirrorIntegrationTest : FunSpec({
                     change.copy(row = change.row.markDeleted(deletedAt))
                 }
                 gateway.pushMirrorState(tombstones).getOrThrow()
-                targetApply.apply(tombstones)
+                val applyResult = targetApply.apply(tombstones)
+                applyResult.deletedRows shouldBe rows.size
 
-                val deletedTarget = MirrorLocalSnapshotRepository(target.database)
+                val physicalTarget = MirrorLocalSnapshotRepository(target.database)
                     .loadDatabaseSnapshot(LINKED_TABLES)
                     .onlySyncIds(syncIds)
-                val deletedRows = deletedTarget.rowsByTable.values.flatten()
-                deletedRows.size shouldBe rows.size
-                deletedRows.forEach { row ->
+                physicalTarget.rowsByTable.values.flatten().size shouldBe 0
+
+                val deletedTarget = MirrorLocalSnapshotRepository(target.database)
+                    .loadSnapshot(LINKED_TABLES)
+                    .onlySyncIds(syncIds)
+                val journalTombstones = deletedTarget.rowsByTable.values.flatten()
+                journalTombstones.size shouldBe rows.size
+                journalTombstones.mapTo(mutableSetOf(), MirrorSyncRow::syncId) shouldBe syncIds
+                journalTombstones.forEach { row ->
                     row.deletedAt shouldBe deletedAt
                 }
                 target.database.batchCostDao
                     .getBySyncId("$prefix-batch")
-                    ?.deletedAt shouldBe deletedAt
+                    .shouldBeNull()
             } finally {
                 runCatching {
                     gateway.pushMirrorState(


### PR DESCRIPTION
## Summary

- avoid redundant remote status probes during the full mirror synchronization cycle
- preserve YDB configuration and error details when synchronization preparation fails
- recompute remaining push and pull changes after reconciliation so concurrent local updates stay visible
- strengthen mirror status and tombstone integration coverage

## Testing

- not run in this session, as requested; the existing tests are reported passing